### PR TITLE
Sb2601: feat(storybook): restore and fix component library stories

### DIFF
--- a/apps/amazin/.storybook/main.js
+++ b/apps/amazin/.storybook/main.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const rootMain = require('../../../.storybook/main');
 
 module.exports = {
@@ -15,7 +16,24 @@ module.exports = {
       config = await rootMain.webpackFinal(config, { configType });
     }
 
-    // add your own webpack tweaks if needed
+    // mirror the app's tsconfig `baseUrl` so bare imports like `src/constants` resolve
+    // the same way they do in the app's own (CRA) build
+    config.resolve.modules = [...(config.resolve.modules || []), path.resolve(__dirname, '..')];
+
+    // the app's global CSS references image sprites with bare paths, e.g.
+    // `url('src/assets/img/nav-sprite.png')`. CRA's own css-loader (nested under
+    // react-scripts) resolves that as a module request; the css-loader Storybook
+    // picks up from the workspace root does not and only tries it relative to the
+    // CSS file, so the build fails. These sprites are decorative and not under
+    // test here, so stop css-loader from trying to resolve/inline them at all
+    // rather than dragging in a second css-loader major version just for this.
+    for (const rule of config.module.rules) {
+      for (const use of rule.use || []) {
+        if (typeof use === 'object' && use.loader && use.loader.includes(`${path.sep}css-loader${path.sep}`)) {
+          use.options = { ...use.options, url: false };
+        }
+      }
+    }
 
     return config;
   }

--- a/apps/amazin/.storybook/preview.js
+++ b/apps/amazin/.storybook/preview.js
@@ -1,10 +1,29 @@
-import '../src/index.css';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { configureStore } from '@reduxjs/toolkit';
+import thunk from 'redux-thunk';
+
+import { rootReducer } from '../src/store';
+
+import '../src/app/app.css';
 import '../src/components/Nav/nav.css';
+import '../src/components/Nav/responsive.css';
 import '../src/screens/Product/VideoScreen/videoScreen.css';
 import '../src/screens/User/CustomerScreen/customerScreen.css';
-import '../src/app/responsive.css';
-import '../src/fonts/fonts.css';
-import '../src/fonts/font-awesome.css';
+import '../src/assets/fonts/fonts.css';
+import '../src/assets/fonts/font-awesome.css';
+
+const store = configureStore({ reducer: rootReducer, preloadedState: {}, middleware: [thunk] });
+
+export const decorators = [
+  (Story) => (
+    <Provider store={store}>
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    </Provider>
+  )
+];
 
 export const parameters = {
   options: {

--- a/apps/amazin/src/stories/CustomInput.stories.js
+++ b/apps/amazin/src/stories/CustomInput.stories.js
@@ -1,0 +1,38 @@
+import CustomInput from '../components/CustomInput';
+
+export default {
+  title: 'Components/Form Custom Input',
+  component: CustomInput
+};
+
+const Template = (props) => (
+  <div className="p-1">
+    <form className="form">
+      <CustomInput {...props} />
+    </form>
+  </div>
+);
+
+const text = 'Sample Text Input';
+const args = {
+  text,
+  type: 'text',
+  placeholder: `Enter ${text}`,
+  hook: [],
+  textarea: false,
+  label: text,
+  wrapClass: 'flex-col',
+  rest: null
+};
+
+export const SameLabel = Template.bind({});
+SameLabel.args = { ...args };
+
+export const OptionalLabel = Template.bind({});
+OptionalLabel.args = { ...args, label: 'Set Or Remove Label' };
+
+export const Inline = Template.bind({});
+Inline.args = { ...args, wrapClass: '' };
+
+export const TextArea = Template.bind({});
+TextArea.args = { ...args, textarea: true };

--- a/apps/amazin/src/stories/Doc/Intro.stories.mdx
+++ b/apps/amazin/src/stories/Doc/Intro.stories.mdx
@@ -4,15 +4,7 @@
 
 ## What is this Storybook?
 
-This is the **design system / component library** behind [Amazin' Amazim][amazim] — the isolated, reusable UI building blocks (Buttons, Inputs, Rating, Pagination, MessageBox, Cards, Nav elements, ...) developed and previewed independently from the rest of the app, includes
-
-- Buttons
-- Input
-- Rating
-- Pagination
-- MessageBox
-- Cards
-- And more to come ..
+This is the **design system / component library** behind [Amazin' Amazim][amazim] — the isolated, reusable UI building blocks (Buttons, Inputs, Rating, Pagination, MessageBox, Cards, Nav elements, ...) developed and previewed independently from the rest of the app.
 
 Browsable live at [ntrix.github.io/amazin-story][amazin-story] or [amazin-storybook.vercel.app][amazin-story-vercel].
 

--- a/apps/amazin/src/stories/Doc/Intro.stories.mdx
+++ b/apps/amazin/src/stories/Doc/Intro.stories.mdx
@@ -1,20 +1,10 @@
 <Meta title="Intro" />
 
-# Welcome to Amazin' Amazim Storybook
+# Amazin' Amazim Design System
 
+## What is this Storybook?
 
-## A React Amazon (& Netflix & ...) Clone Project
-
-
-## What is Storybook?
-
-Storybook is a tool for UI development. It makes development faster and easier by isolating components.
-This allows you to work on one component at a time. You can develop entire UIs without needing to start up a complex dev stack, force certain data into your database, or navigate around your application.
-
-
-## What is [Amazin' Amazim Storybook][amazin-story]
-
-This is the collection of components that I wrote for [amazim.netlify.app][amazim], includes
+This is the **design system / component library** behind [Amazin' Amazim][amazim] — the isolated, reusable UI building blocks (Buttons, Inputs, Rating, Pagination, MessageBox, Cards, Nav elements, ...) developed and previewed independently from the rest of the app, includes
 
 - Buttons
 - Input
@@ -24,13 +14,17 @@ This is the collection of components that I wrote for [amazim.netlify.app][amazi
 - Cards
 - And more to come ..
 
-[https://ntrix.github.io/amazin-story/][amazin-story] or [https://amazin-storybook.vercel.app/][amazin-story-vercel]
+Browsable live at [ntrix.github.io/amazin-story][amazin-story] or [amazin-storybook.vercel.app][amazin-story-vercel].
+
+### What is Storybook?
+
+Storybook is a tool for UI development. It makes development faster and easier by isolating components.
+This allows you to work on one component at a time. You can develop entire UIs without needing to start up a complex dev stack, force certain data into your database, or navigate around your application.
 
 ## What is Amazim?
 
 This is not only an online shop/platform/clone of Amazon, Netflix or something else built with a js-framework,
 but also a long term example experimenting some **modern**, **real-world**, **maybe unstable** React APIs, Nx, Mobile friendly PWA and also some Backend technologies in my spare time.
-
 
 ## Tech stack: MERN & Co.
 
@@ -45,7 +39,7 @@ but also a long term example experimenting some **modern**, **real-world**, **ma
 - UI modules:
   + [Swiper][swiper]
   + ...
-- [Vercel][vercel]
+- [Netlify][netlify]
 
 ### Backend Stack
 
@@ -68,11 +62,13 @@ but also a long term example experimenting some **modern**, **real-world**, **ma
 [mongo]: https://www.mongodb.com/
 [mongoose]: https://mongoosejs.com/
 [vercel]: https://vercel.com/
+[netlify]: https://www.netlify.com/
 [heroku]: https://www.heroku.com/
-
+[render]: https://render.com/
+[codecov]: https://codecov.io/
+[sonar]: https://sonarcloud.io/
 
 ## Working application
-
 
 ### Live demo, PWA, QR code:
 
@@ -90,7 +86,6 @@ Frontend (old version): [github.com/ntrix/amazin/tree/org-cra][FEv1]
 
 Backend: [github.com/ntrix/amazin-be][BEv1]
 
-
 ## Learning by Doing
 
 **"Divide to conquer"** - Lao Tsu (604-531 BC).
@@ -98,22 +93,25 @@ Backend: [github.com/ntrix/amazin-be][BEv1]
 When I look at the application, it is **huge**. When the task is huge, you usually don't know how to start working with them.
 I had to break the big task into smaller parts, do it step by step and enjoy learning.
 
-Yes, **Learning by Doing ** that's my approach. If you see a long path ahead, don't heap or run or give up, just divide the path(process) to steps and make (conquer) the first one, and then another one.
+Yes, **Learning by Doing** that's my approach. If you see a long path ahead, don't heap or run or give up, just divide the path(process) to steps and make (conquer) the first one, and then another one.
 I learned a lot of stuff, also renew and update my knowledge just by doing. You might too have a curiosity about the process of building the same scale app as well, but just let's do it.
-
 
 | Part | Description                                                                     | Status |
 | ---- | ------------------------------------------------------------------------------- | ------ |
 | 01a  | Database: [Mongo DB][mongo], [Mongoose][mongoose], [Atlas][atlas]               | Done   |
 | 01b  | Backend v1: [Source][BEv1], [Node][Node], [Express][express]                    | Done   |
 | 01c  | Backend Deploy: [Heroku][heroku] / Firebase                                     | Done   |
+| 01d  | Heroku account deleted (long inactivity) → migrated to Cyclic.sh (serverless)   | Done   |
+| 01e  | Cyclic.sh shut down (2024) → migrated to [Render][render] (free tier)          | Done   |
 | 02a  | Frontend v1: [Source][FEv1], [React][react], [Redux][redux]                     | Done   |
 | 02b  | Frontend Deploy: [Vercel][vercel]                                               | Done   |
+| 02c  | Vercel disabled → migrated to [Netlify][netlify]                               | Done   |
 | 03a  | Frontend v3: [Source][FEnx], Migration to [Nx][Nx]                              | Done   |
-| 03b  | [Testing in React][testing]                                                     | Doing  |
-| 03c  | E2E testing with [Cypress][cy]                                                  | Doing  |
+| 03b  | [Testing in React][testing]: unit tests (utils, redux, hooks, screens) + CI     | Done   |
+| 03c  | E2E testing with [Cypress][cy]: purchase & seller flows                        | Done   |
+| 03d  | Code quality: [Codecov][codecov] coverage + [SonarQube Cloud][sonar] code smells | Done   |
 | 04   | Performance & Experiment some [unstable React API][reactAPI]                    | Done   |
-| 05a  | [AWS Cloud Backend?][aws]                                                       | **Todo**   |
+| 05a  | ~~[AWS Cloud Backend?][aws]~~ (no free tier anymore) — use Render instead        | Done   |
 | 05b  | Backend [DB cache][redis]                                                       | Doing  |
 | 06   | AB Testing, Error Tracing [(React Profiler?)][profiler]                         | **Todo**   |
 | ..   | ..                                                                              | ..     |
@@ -145,4 +143,4 @@ I learned a lot of stuff, also renew and update my knowledge just by doing. You 
 [amazin-story]: https://ntrix.github.io/amazin-story/
 [amazin-story-vercel]: https://amazin-storybook.vercel.app/
 
-[demo]: https://raw.githubusercontent.com/ntrix/amazin/nx/apps/amazin/src/stories/img/amazim-react-demo-ntien.gif
+[demo]: https://raw.githubusercontent.com/ntrix/amazin/nx/apps/amazin/src/stories/img/gif/Nav%20Currency%20Search%20Suggest%20Category%20Filter.gif

--- a/apps/amazin/src/stories/Doc/Intro.stories.mdx
+++ b/apps/amazin/src/stories/Doc/Intro.stories.mdx
@@ -1,0 +1,148 @@
+<Meta title="Intro" />
+
+# Welcome to Amazin' Amazim Storybook
+
+
+## A React Amazon (& Netflix & ...) Clone Project
+
+
+## What is Storybook?
+
+Storybook is a tool for UI development. It makes development faster and easier by isolating components.
+This allows you to work on one component at a time. You can develop entire UIs without needing to start up a complex dev stack, force certain data into your database, or navigate around your application.
+
+
+## What is [Amazin' Amazim Storybook][amazin-story]
+
+This is the collection of components that I wrote for [amazim.netlify.app][amazim], includes
+
+- Buttons
+- Input
+- Rating
+- Pagination
+- MessageBox
+- Cards
+- And more to come ..
+
+[https://ntrix.github.io/amazin-story/][amazin-story] or [https://amazin-storybook.vercel.app/][amazin-story-vercel]
+
+## What is Amazim?
+
+This is not only an online shop/platform/clone of Amazon, Netflix or something else built with a js-framework,
+but also a long term example experimenting some **modern**, **real-world**, **maybe unstable** React APIs, Nx, Mobile friendly PWA and also some Backend technologies in my spare time.
+
+
+## Tech stack: MERN & Co.
+
+### Frontend Stack
+
+![Tech Stack Frontend][stackFE]
+
+- [Nx CLI][nx]
+- [React JS][react]
+- [Redux][redux]
+- [Cypress][cy]
+- UI modules:
+  + [Swiper][swiper]
+  + ...
+- [Vercel][vercel]
+
+### Backend Stack
+
+![Tech Stack Backtend][stackBE]
+- [Node JS][Node]
+- [Express JS][express]
+
+- [Mongo DB][mongo]
+- [Mongoose][mongoose]
+- [Mongo DB Atlas][atlas]
+- [Heroku][heroku]
+- [optional AWS][aws]
+
+[nx]: https://nx.dev/
+[react]: https://reactjs.org/
+[redux]: https://redux.js.org/
+[swiper]: https://swiperjs.com/
+[node]: https://nodejs.org/
+[express]: https://expressjs.com/
+[mongo]: https://www.mongodb.com/
+[mongoose]: https://mongoosejs.com/
+[vercel]: https://vercel.com/
+[heroku]: https://www.heroku.com/
+
+
+## Working application
+
+
+### Live demo, PWA, QR code:
+
+| **[amazim.netlify.app][amazim]**   | **[amazin.tiennguyen.de][amazin]**   |
+| ----------------------------------- | ------------------------------------- |
+| ![amazim.netlify.app QR][qr-amazim] | ![amazin.tiennguyen.de QR][qr-amazin] |
+
+![Amazon Clone built with React and Node][demo]
+
+### Source code:
+
+Frontend: [github.com/ntrix/amazin][FEnx]
+
+Frontend (old version): [github.com/ntrix/amazin/tree/org-cra][FEv1]
+
+Backend: [github.com/ntrix/amazin-be][BEv1]
+
+
+## Learning by Doing
+
+**"Divide to conquer"** - Lao Tsu (604-531 BC).
+
+When I look at the application, it is **huge**. When the task is huge, you usually don't know how to start working with them.
+I had to break the big task into smaller parts, do it step by step and enjoy learning.
+
+Yes, **Learning by Doing ** that's my approach. If you see a long path ahead, don't heap or run or give up, just divide the path(process) to steps and make (conquer) the first one, and then another one.
+I learned a lot of stuff, also renew and update my knowledge just by doing. You might too have a curiosity about the process of building the same scale app as well, but just let's do it.
+
+
+| Part | Description                                                                     | Status |
+| ---- | ------------------------------------------------------------------------------- | ------ |
+| 01a  | Database: [Mongo DB][mongo], [Mongoose][mongoose], [Atlas][atlas]               | Done   |
+| 01b  | Backend v1: [Source][BEv1], [Node][Node], [Express][express]                    | Done   |
+| 01c  | Backend Deploy: [Heroku][heroku] / Firebase                                     | Done   |
+| 02a  | Frontend v1: [Source][FEv1], [React][react], [Redux][redux]                     | Done   |
+| 02b  | Frontend Deploy: [Vercel][vercel]                                               | Done   |
+| 03a  | Frontend v3: [Source][FEnx], Migration to [Nx][Nx]                              | Done   |
+| 03b  | [Testing in React][testing]                                                     | Doing  |
+| 03c  | E2E testing with [Cypress][cy]                                                  | Doing  |
+| 04   | Performance & Experiment some [unstable React API][reactAPI]                    | Done   |
+| 05a  | [AWS Cloud Backend?][aws]                                                       | **Todo**   |
+| 05b  | Backend [DB cache][redis]                                                       | Doing  |
+| 06   | AB Testing, Error Tracing [(React Profiler?)][profiler]                         | **Todo**   |
+| ..   | ..                                                                              | ..     |
+| 09a  | [StoryBook UI Components][storybook], isolate UI/UI libs                        | Done   |
+| 09b  | [Documentation][mdx]                                                            | Doing  |
+| 09c  | Migration to TypeScript                                                         | Done   |
+
+[atlas]: https://www.mongodb.com/cloud/atlas
+[BEv1]: https://github.com/ntrix/amazin-be
+[FEv1]: https://github.com/ntrix/amazin/tree/org-cra
+[FEnx]: https://github.com/ntrix/amazin
+[testing]: https://testing-library.com/
+[reactAPI]: https://reactjs.org/docs/concurrent-mode-suspense.html
+[storybook]: https://storybook.js.org/
+[cy]: https://www.cypress.io/
+[swagger]: https://swagger.io/
+
+[stackFE]: https://raw.githubusercontent.com/ntrix/amazin/nx/apps/amazin/src/stories/img/nx-react-cy-redux-swiper-vercel-1000.png
+[stackBE]: https://raw.githubusercontent.com/ntrix/amazin/nx/apps/amazin/src/stories/img/mongo-express-react-node-atlas-mongoose-heroku-1000.png
+[amazim]: https://amazim.netlify.app/
+[amazin]: https://amazin.tiennguyen.de/
+[aws]: https://aws.com/
+[redis]: https://redis.com/
+[profiler]: https://reactjs.org/docs/profiler.html
+[mdx]: https://mdxjs.com/
+
+[qr-amazim]: https://raw.githubusercontent.com/ntrix/amazin/nx/apps/amazin/src/stories/img/qrcode.amazim.netlify.app.png
+[qr-amazin]: https://raw.githubusercontent.com/ntrix/amazin/nx/apps/amazin/src/stories/img/qrcode.amazin.tiennguyen.de.png
+[amazin-story]: https://ntrix.github.io/amazin-story/
+[amazin-story-vercel]: https://amazin-storybook.vercel.app/
+
+[demo]: https://raw.githubusercontent.com/ntrix/amazin/nx/apps/amazin/src/stories/img/amazim-react-demo-ntien.gif

--- a/apps/amazin/src/stories/Doc/Structure.Backend.stories.mdx
+++ b/apps/amazin/src/stories/Doc/Structure.Backend.stories.mdx
@@ -1,0 +1,35 @@
+<Meta title="Structure/Backend" />
+
+## Backend
+
+```
+.
+├── auth
+│   ├── rolls.js
+│   └── token.js
+├── controllers
+│   ├── configControllers.js
+│   ├── orderControllers.js
+│   ├── productControllers.js
+│   ├── uploadControllers.js
+│   └── userControllers.js
+├── middleware
+│   └── validate.js
+├── models
+│   ├── orderModel.js
+│   ├── productModel.js
+│   └── userModel.js
+├── package-lock.json
+├── package.json
+├── routes
+│   ├── configRoute.js
+│   ├── orderRoute.js
+│   ├── productRoute.js
+│   ├── uploadRoute.js
+│   └── userRoute.js
+├── seed.data.js
+├── server.js
+└── uploads
+    └── ...temp.uploads
+
+```

--- a/apps/amazin/src/stories/Doc/Structure.Frontend.stories.mdx
+++ b/apps/amazin/src/stories/Doc/Structure.Frontend.stories.mdx
@@ -1,0 +1,420 @@
+<Meta title="Structure/Frontend" />
+
+## Frontend
+
+```
+.
+├── README.md
+├── apps
+│   ├── amazin
+│   │   ├── config-overrides.js
+│   │   ├── jest.config.js
+│   │   ├── package.json
+│   │   ├── public
+│   │   │   ├── apple-touch-icon-512.png
+│   │   │   ├── awesome
+│   │   │   │   ├── FontAwesome.eot
+│   │   │   │   ├── FontAwesome.svg
+│   │   │   │   ├── FontAwesome.ttf
+│   │   │   │   ├── FontAwesome.woff
+│   │   │   │   ├── FontAwesome.woff2
+│   │   │   │   └── font-awesome.min.css
+│   │   │   ├── chrome-icon-circle-192.png
+│   │   │   ├── favicon.ico
+│   │   │   ├── images
+│   │   │   │   ├── banner-Fashion.jpg
+│   │   │   │   ├── banner-fs.jpg
+│   │   │   │   ├── default-logo.png
+│   │   │   │   ├── icon-account.png
+│   │   │   │   ├── icon-contact.png
+│   │   │   │   ├── icon-covid19.png
+│   │   │   │   ├── icon-digital.png
+│   │   │   │   ├── icon-gift.png
+│   │   │   │   ├── icon-order.png
+│   │   │   │   ├── icon-payment.png
+│   │   │   │   ├── icon-report.png
+│   │   │   │   ├── icon-return.png
+│   │   │   │   ├── icon-video.png
+│   │   │   │   ├── logo1.png
+│   │   │   │   ├── logo2.png
+│   │   │   │   ├── no-image-p.png
+│   │   │   │   └── no-image.png
+│   │   │   ├── index.html
+│   │   │   ├── manifest.json
+│   │   │   ├── robots.txt
+│   │   │   └── service-worker.js
+│   │   ├── src
+│   │   │   ├── __mocks__
+│   │   │   │   ├── index.js
+│   │   │   │   └── store.js
+│   │   │   ├── __tests__
+│   │   │   │   ├── App.js
+│   │   │   │   ├── apis
+│   │   │   │   │   └── product.http
+│   │   │   │   └── components
+│   │   │   │       └── Button.js
+│   │   │   ├── apis
+│   │   │   │   ├── axiosClient.js
+│   │   │   │   ├── cartAPI.js
+│   │   │   │   ├── orderAPI.js
+│   │   │   │   ├── productAPI.js
+│   │   │   │   ├── suspenseAPI.js
+│   │   │   │   └── userAPI.js
+│   │   │   ├── app
+│   │   │   │   ├── Nav.js
+│   │   │   │   ├── index.js
+│   │   │   │   ├── nav.css
+│   │   │   │   └── responsive.css
+│   │   │   ├── components
+│   │   │   │   ├── Button.js
+│   │   │   │   ├── CheckCell.js
+│   │   │   │   ├── CustomCheck.js
+│   │   │   │   ├── CustomInput.js
+│   │   │   │   ├── CustomRadio.js
+│   │   │   │   ├── CustomSelect.js
+│   │   │   │   ├── CustomSuspense.js
+│   │   │   │   ├── Fallbacks.js
+│   │   │   │   ├── LoadingBox.js
+│   │   │   │   ├── LoadingOrError.js
+│   │   │   │   ├── MessageBox.js
+│   │   │   │   ├── Nav
+│   │   │   │   │   ├── InnerMenuItem.js
+│   │   │   │   │   ├── MenuItem.js
+│   │   │   │   │   ├── NavBelt
+│   │   │   │   │   │   ├── NavButton
+│   │   │   │   │   │   │   ├── NavBtnDropdown.js
+│   │   │   │   │   │   │   ├── NavBtnFacade.js
+│   │   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   │   └── useBtnControl.js
+│   │   │   │   │   │   ├── NavCart.js
+│   │   │   │   │   │   ├── NavCurrency
+│   │   │   │   │   │   │   ├── DropdownCurrency
+│   │   │   │   │   │   │   │   ├── CurrencyRate.js
+│   │   │   │   │   │   │   │   ├── DropdownCurrencyItem.js
+│   │   │   │   │   │   │   │   └── index.js
+│   │   │   │   │   │   │   └── index.js
+│   │   │   │   │   │   ├── NavLocator.js
+│   │   │   │   │   │   ├── NavLogo.js
+│   │   │   │   │   │   ├── NavUser
+│   │   │   │   │   │   │   ├── DropdownUser.js
+│   │   │   │   │   │   │   ├── adminTemplate.js
+│   │   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   │   ├── sellerTemplate.js
+│   │   │   │   │   │   │   ├── signinTemplate.js
+│   │   │   │   │   │   │   ├── useDropMenuCreator.js
+│   │   │   │   │   │   │   └── userTemplate.js
+│   │   │   │   │   │   └── index.js
+│   │   │   │   │   ├── NavMain
+│   │   │   │   │   │   ├── NavMainItem.js
+│   │   │   │   │   │   ├── OpenSidebarBtn.js
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   └── navMainTemplate.js
+│   │   │   │   │   ├── NavSearch
+│   │   │   │   │   │   ├── SearchBox
+│   │   │   │   │   │   │   ├── BoxLeft.js
+│   │   │   │   │   │   │   ├── BoxMiddle.js
+│   │   │   │   │   │   │   ├── BoxRight.js
+│   │   │   │   │   │   │   ├── SearchBtn.js
+│   │   │   │   │   │   │   ├── SearchCatScope
+│   │   │   │   │   │   │   │   ├── SearchCatDropdown.js
+│   │   │   │   │   │   │   │   ├── SearchCatItem.js
+│   │   │   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   │   │   └── useClickFocus.js
+│   │   │   │   │   │   │   ├── SearchInput
+│   │   │   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   │   │   ├── useKeyInput.js
+│   │   │   │   │   │   │   │   └── useSuggestBox.js
+│   │   │   │   │   │   │   ├── SearchSuggests.js
+│   │   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   │   └── useSubmit.js
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   ├── useOutline.js
+│   │   │   │   │   │   └── useOutsideClick.js
+│   │   │   │   │   ├── SearchBanner.js
+│   │   │   │   │   ├── SidebarMenu
+│   │   │   │   │   │   ├── ShadowWrapper.js
+│   │   │   │   │   │   ├── SidebarHeader.js
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   └── sidebarTemplate.js
+│   │   │   │   │   └── SubNavCategories
+│   │   │   │   │       ├── SubNavItem.js
+│   │   │   │   │       └── index.js
+│   │   │   │   ├── PageRedirect.js
+│   │   │   │   ├── Pagination.js
+│   │   │   │   ├── Rating.js
+│   │   │   │   ├── ReviewCard.js
+│   │   │   │   ├── RowLegend.js
+│   │   │   │   ├── SortFilter.js
+│   │   │   │   └── SuccessModal.js
+│   │   │   ├── constants
+│   │   │   │   └── index.js
+│   │   │   ├── fonts
+│   │   │   │   ├── AmazonEmber_W_Bd.eot
+│   │   │   │   ├── AmazonEmber_W_Bd.woff
+│   │   │   │   ├── AmazonEmber_W_Bd.woff2
+│   │   │   │   ├── AmazonEmber_W_He.eot
+│   │   │   │   ├── AmazonEmber_W_He.woff
+│   │   │   │   ├── AmazonEmber_W_He.woff2
+│   │   │   │   ├── AmazonEmber_W_Rg.eot
+│   │   │   │   ├── AmazonEmber_W_Rg.woff
+│   │   │   │   ├── AmazonEmber_W_Rg.woff2
+│   │   │   │   ├── AmazonEmber_W_SBd.eot
+│   │   │   │   ├── AmazonEmber_W_SBd.woff
+│   │   │   │   ├── AmazonEmber_W_SBd.woff2
+│   │   │   │   ├── FontAwesome.eot
+│   │   │   │   ├── FontAwesome.svg
+│   │   │   │   ├── FontAwesome.ttf
+│   │   │   │   ├── FontAwesome.woff
+│   │   │   │   ├── FontAwesome.woff2
+│   │   │   │   ├── font-awesome.css
+│   │   │   │   └── fonts.css
+│   │   │   ├── hooks
+│   │   │   │   ├── useDebounce.js
+│   │   │   │   ├── useDoThenDebounce.js
+│   │   │   │   ├── useSafeState.js
+│   │   │   │   └── useShadow.js
+│   │   │   ├── img
+│   │   │   │   ├── a.svg
+│   │   │   │   ├── banner-Save.jpg
+│   │   │   │   ├── banner-Save1.jpg
+│   │   │   │   ├── banner-alarm.jpg
+│   │   │   │   ├── banner-bestseller.jpg
+│   │   │   │   ├── banner-camera.jpg
+│   │   │   │   ├── banner-fs-lila.jpg
+│   │   │   │   ├── banner-fs.jpg
+│   │   │   │   ├── banner-giftbox.jpg
+│   │   │   │   ├── banner-ship.jpg
+│   │   │   │   ├── banner-shipping.jpg
+│   │   │   │   ├── flags-globe.png
+│   │   │   │   ├── flags.png
+│   │   │   │   ├── load-xs.gif
+│   │   │   │   ├── load.gif
+│   │   │   │   ├── nav-sprite.png
+│   │   │   │   └── travoltaNotFound.gif
+│   │   │   ├── index.css
+│   │   │   ├── index.js
+│   │   │   ├── layouts
+│   │   │   │   ├── BaseTable.js
+│   │   │   │   ├── Form.js
+│   │   │   │   └── Header.js
+│   │   │   ├── react-app-env.d.ts
+│   │   │   ├── routes
+│   │   │   │   ├── AdminRoute.js
+│   │   │   │   ├── MainRoutes.js
+│   │   │   │   ├── PrivateRoute.js
+│   │   │   │   ├── SellerRoute.js
+│   │   │   │   ├── SuspenseRoute.js
+│   │   │   │   └── TokenRoutes.js
+│   │   │   ├── screens
+│   │   │   │   ├── Auth
+│   │   │   │   │   ├── ErrorBaseWithBtn.js
+│   │   │   │   │   ├── ErrorScreen.js
+│   │   │   │   │   ├── RegisterScreen
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   └── useRegisterEffect.js
+│   │   │   │   │   ├── Screen404.js
+│   │   │   │   │   └── SigninScreen
+│   │   │   │   │       ├── index.js
+│   │   │   │   │       └── useSigninEffect.js
+│   │   │   │   ├── Checkout
+│   │   │   │   │   ├── CartScreen
+│   │   │   │   │   │   ├── CartRowItem.js
+│   │   │   │   │   │   ├── CartTable.js
+│   │   │   │   │   │   ├── SumCard.js
+│   │   │   │   │   │   └── index.js
+│   │   │   │   │   ├── CheckoutSteps.js
+│   │   │   │   │   ├── PaymentMethodScreen.js
+│   │   │   │   │   └── ShippingAddressScreen
+│   │   │   │   │       ├── index.js
+│   │   │   │   │       └── useShipInfo.js
+│   │   │   │   ├── HomeScreen
+│   │   │   │   │   ├── FeaturedSection.js
+│   │   │   │   │   ├── SellerSlide.js
+│   │   │   │   │   ├── SliderSection.js
+│   │   │   │   │   └── index.js
+│   │   │   │   ├── Order
+│   │   │   │   │   ├── OrderHistoryScreen.js
+│   │   │   │   │   ├── OrderListScreen.js
+│   │   │   │   │   ├── OrderSumScreen
+│   │   │   │   │   │   ├── AdminDeliveryCard.js
+│   │   │   │   │   │   ├── OrderSumCard.js
+│   │   │   │   │   │   ├── PaypalCard.js
+│   │   │   │   │   │   ├── StatusBox.js
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   └── usePaypal.js
+│   │   │   │   │   ├── PlaceOrderScreen
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   └── useCart.js
+│   │   │   │   │   └── components
+│   │   │   │   │       ├── InfoCard.js
+│   │   │   │   │       ├── ListRow.js
+│   │   │   │   │       ├── OrderItem.js
+│   │   │   │   │       ├── OrderItemsCard.js
+│   │   │   │   │       ├── OrderTable.js
+│   │   │   │   │       ├── PaymentMethodCard.js
+│   │   │   │   │       └── ShippingAddressCard.js
+│   │   │   │   ├── Product
+│   │   │   │   │   ├── DealScreen
+│   │   │   │   │   │   ├── dealScreen.css
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   └── useDealScreen.js
+│   │   │   │   │   ├── ProductEditScreen
+│   │   │   │   │   │   ├── ImageRows.js
+│   │   │   │   │   │   ├── ImageSection
+│   │   │   │   │   │   │   ├── NewImageInput.js
+│   │   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   │   └── useImageHandlers.js
+│   │   │   │   │   │   └── index.js
+│   │   │   │   │   ├── ProductListScreen
+│   │   │   │   │   │   ├── Table.js
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   └── useProductList.js
+│   │   │   │   │   ├── ProductScreen
+│   │   │   │   │   │   ├── BackBanner.js
+│   │   │   │   │   │   ├── ProductDescription.js
+│   │   │   │   │   │   ├── ProductImages.js
+│   │   │   │   │   │   ├── ProductInStock.js
+│   │   │   │   │   │   ├── ProductReview.js
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   └── productScreen.css
+│   │   │   │   │   ├── SearchScreen
+│   │   │   │   │   │   ├── SearchFilterColumn
+│   │   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   │   └── listItemCreator.js
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   └── useSearchFilter.js
+│   │   │   │   │   ├── SellerScreen
+│   │   │   │   │   │   ├── SellerCard.js
+│   │   │   │   │   │   └── index.js
+│   │   │   │   │   ├── VideoScreen
+│   │   │   │   │   │   ├── VideoNavHeader.js
+│   │   │   │   │   │   ├── VideoRow.js
+│   │   │   │   │   │   ├── components
+│   │   │   │   │   │   │   ├── ButtonBuy.js
+│   │   │   │   │   │   │   ├── ButtonSell.js
+│   │   │   │   │   │   │   ├── ButtonTrailer.js
+│   │   │   │   │   │   │   ├── UTube.js
+│   │   │   │   │   │   │   ├── VideoBanner.js
+│   │   │   │   │   │   │   └── VideoCard.js
+│   │   │   │   │   │   ├── index.js
+│   │   │   │   │   │   ├── useMovieList.js
+│   │   │   │   │   │   └── videoScreen.css
+│   │   │   │   │   └── components
+│   │   │   │   │       ├── PriceNow.js
+│   │   │   │   │       ├── PriceTag.js
+│   │   │   │   │       ├── ProductCard.js
+│   │   │   │   │       └── ProductColumn.js
+│   │   │   │   └── User
+│   │   │   │       ├── ContactScreen
+│   │   │   │       │   ├── ContactSubject.js
+│   │   │   │       │   ├── SubjectTemplate.js
+│   │   │   │       │   ├── index.js
+│   │   │   │       │   └── useContact.js
+│   │   │   │       ├── CurrencyScreen
+│   │   │   │       │   ├── CurrencySection
+│   │   │   │       │   │   ├── CurrencyOptions.js
+│   │   │   │       │   │   ├── index.js
+│   │   │   │       │   │   └── useCurrency.js
+│   │   │   │       │   ├── LanguageSection
+│   │   │   │       │   │   ├── LanguageOption.js
+│   │   │   │       │   │   ├── LanguageOptions.js
+│   │   │   │       │   │   ├── index.js
+│   │   │   │       │   │   └── languageTemplate.js
+│   │   │   │       │   ├── currencyScreen.css
+│   │   │   │       │   └── index.js
+│   │   │   │       ├── CustomerScreen
+│   │   │   │       │   ├── CustomerCard.js
+│   │   │   │       │   ├── CustomerHelpSection.js
+│   │   │   │       │   ├── customerMenuTemplate.js
+│   │   │   │       │   ├── customerScreen.css
+│   │   │   │       │   └── index.js
+│   │   │   │       ├── MapScreen
+│   │   │   │       │   ├── MapSearchBox.js
+│   │   │   │       │   ├── index.js
+│   │   │   │       │   └── useMapAPIs.js
+│   │   │   │       ├── ProfileScreen
+│   │   │   │       │   ├── SellerProfileSection.js
+│   │   │   │       │   ├── UserProfileSection.js
+│   │   │   │       │   ├── index.js
+│   │   │   │       │   └── useProfile.js
+│   │   │   │       ├── UserEditScreen
+│   │   │   │       │   ├── index.js
+│   │   │   │       │   └── useUserEdit.js
+│   │   │   │       └── UserListScreen
+│   │   │   │           ├── index.js
+│   │   │   │           └── useUserList.js
+│   │   │   ├── serviceWorker.js
+│   │   │   ├── slice
+│   │   │   │   ├── CartSlice.js
+│   │   │   │   ├── OrderSlice.js
+│   │   │   │   ├── ProductSlice.js
+│   │   │   │   ├── ReduxToolKitClient.js
+│   │   │   │   └── UserSlice.js
+│   │   │   ├── store
+│   │   │   │   └── store.js
+│   │   │   ├── stories
+│   │   │   │   ├── CustomInput.stories.js
+│   │   │   │   ├── Doc
+│   │   │   │   │   ├── Intro.stories.mdx
+│   │   │   │   │   ├── Structure.Backend.stories.mdx
+│   │   │   │   │   ├── Structure.Frontend.stories.mdx
+│   │   │   │   │   └── Structure.Public.stories.mdx
+│   │   │   │   ├── LoadingBox.stories.js
+│   │   │   │   ├── MessageBox.stories.js
+│   │   │   │   ├── Nav
+│   │   │   │   │   └── CartLinkBtn.stories.js
+│   │   │   │   ├── Product
+│   │   │   │   │   ├── ButtonBuy.stories.js
+│   │   │   │   │   ├── ButtonSell.stories.js
+│   │   │   │   │   └── VideoCard.stories.js
+│   │   │   │   ├── SortFilter.stories.js
+│   │   │   │   ├── User
+│   │   │   │   │   └── CustomerCard.stories.js
+│   │   │   │   ├── button.stories.js
+│   │   │   │   ├── img
+│   │   │   │   │   ├── Redux.png
+│   │   │   │   │   ├── mongo-express-react-node-atlas-mongoose-heroku-1000.png
+│   │   │   │   │   ├── mongo-express-react-node-heroku-dbatlas.png
+│   │   │   │   │   ├── mongoose.png
+│   │   │   │   │   ├── nx-logo.png
+│   │   │   │   │   ├── nx-react-cy-redux-swiper-vercel-1000.png
+│   │   │   │   │   ├── nx-react-cy.jpeg
+│   │   │   │   │   ├── qrcode.amazim.store.png
+│   │   │   │   │   ├── qrcode.amazin.ntien.com.png
+│   │   │   │   │   └── vercel-inc-logo-vector.png
+│   │   │   │   ├── pagination.stories.js
+│   │   │   │   └── rating.stories.js
+│   │   │   └── utils
+│   │   │       ├── findSuggest.js
+│   │   │       └── index.js
+│   │   └── tsconfig.json
+│   └── amazin-e2e
+│       ├── cypress.json
+│       ├── src
+│       │   ├── fixtures
+│       │   │   └── example.json
+│       │   ├── integration
+│       │   │   └── app.spec.ts
+│       │   ├── plugins
+│       │   │   └── index.js
+│       │   └── support
+│       │       ├── app.po.ts
+│       │       ├── commands.ts
+│       │       └── index.ts
+│       ├── tsconfig.e2e.json
+│       └── tsconfig.json
+├── babel.config.json
+├── jest.config.js
+├── jest.preset.js
+├── libs
+├── nx.json
+├── package.json
+├── tools
+│   ├── generators
+│   └── tsconfig.tools.json
+├── tsconfig.base.json
+├── workspace.json
+└── yarn.lock
+...
+
+```

--- a/apps/amazin/src/stories/Doc/Structure.Public.stories.mdx
+++ b/apps/amazin/src/stories/Doc/Structure.Public.stories.mdx
@@ -1,0 +1,40 @@
+<Meta title="Structure/Public" />
+
+## Frontend Public Folder
+
+```
+.
+├── apple-touch-icon-512.png
+├── awesome
+│   ├── FontAwesome.eot
+│   ├── FontAwesome.svg
+│   ├── FontAwesome.ttf
+│   ├── FontAwesome.woff
+│   ├── FontAwesome.woff2
+│   └── font-awesome.min.css
+├── chrome-icon-circle-192.png
+├── favicon.ico
+├── images
+│   ├── banner-Fashion.jpg
+│   ├── banner-fs.jpg
+│   ├── default-logo.png
+│   ├── icon-account.png
+│   ├── icon-contact.png
+│   ├── icon-covid19.png
+│   ├── icon-digital.png
+│   ├── icon-gift.png
+│   ├── icon-order.png
+│   ├── icon-payment.png
+│   ├── icon-report.png
+│   ├── icon-return.png
+│   ├── icon-video.png
+│   ├── logo1.png
+│   ├── logo2.png
+│   ├── no-image-p.png
+│   └── no-image.png
+├── index.html
+├── manifest.json
+├── robots.txt
+└── service-worker.js
+
+```

--- a/apps/amazin/src/stories/LoadingBox.stories.js
+++ b/apps/amazin/src/stories/LoadingBox.stories.js
@@ -1,0 +1,19 @@
+import LoadingBox from '../components/LoadingBox';
+
+export default {
+  title: 'Components/Loading Box',
+  component: LoadingBox
+};
+
+const Template = (props) => (
+  <div className="p-1">
+    <LoadingBox {...props} />
+  </div>
+);
+const args = { xl: false, wrapClass: '' };
+
+export const LoadingNormal = Template.bind({});
+LoadingNormal.args = { ...args };
+
+export const LoadingXL = Template.bind({});
+LoadingXL.args = { ...args, xl: true };

--- a/apps/amazin/src/stories/MessageBox.stories.js
+++ b/apps/amazin/src/stories/MessageBox.stories.js
@@ -1,0 +1,33 @@
+import MessageBox from '../components/MessageBox';
+
+export default {
+  title: 'Components/Message Box',
+  component: MessageBox
+};
+
+const Template = (props) => (
+  <div className="p-1">
+    <MessageBox {...props} />
+  </div>
+);
+
+const msg = 'Test Message Info Message Box Here';
+
+const args = {
+  msg,
+  show: true,
+  variant: 'info',
+  wrapClass: ''
+};
+
+export const InfoMessage = Template.bind(args);
+InfoMessage.args = { ...args };
+
+export const ErrorMessage = Template.bind({});
+ErrorMessage.args = { ...args, variant: 'danger' };
+
+export const MultiMessages = Template.bind({});
+MultiMessages.args = { ...args, msg: [msg, msg, msg] };
+
+export const SuccessMessage = Template.bind({});
+SuccessMessage.args = { ...args, variant: 'success' };

--- a/apps/amazin/src/stories/Nav/CartLinkBtn.stories.js
+++ b/apps/amazin/src/stories/Nav/CartLinkBtn.stories.js
@@ -1,0 +1,12 @@
+import NavCart from '../../components/Nav/NavBelt/NavCart';
+
+export default {
+  title: 'Components/Nav/Cart Link Button',
+  component: NavCart
+};
+
+const Template = (args) => <NavCart {...args} />;
+const args = { to: '/cart' };
+
+export const CartLink = Template.bind({});
+CartLink.args = { ...args };

--- a/apps/amazin/src/stories/Product/ButtonBuy.stories.js
+++ b/apps/amazin/src/stories/Product/ButtonBuy.stories.js
@@ -1,0 +1,12 @@
+import ButtonBuy from '../../components/Product/VideoScreen/components/ButtonBuy';
+
+export default {
+  title: 'Components/Screens/Product/Video Screen/Button Buy',
+  component: ButtonBuy
+};
+
+const Template = (props) => <ButtonBuy {...props} />;
+const args = { movie: undefined, LinkTo: (props) => <div {...props} /> };
+
+export const BuyRent = Template.bind({});
+BuyRent.args = { ...args };

--- a/apps/amazin/src/stories/Product/ButtonSell.stories.js
+++ b/apps/amazin/src/stories/Product/ButtonSell.stories.js
@@ -1,0 +1,18 @@
+import { SellerButton } from '../../components/Product/VideoScreen/components/ButtonSell';
+
+export default {
+  title: 'Components/Screens/Product/Video Screen/Button Sell',
+  component: SellerButton
+};
+
+const Template = (props) => <SellerButton {...props} />;
+const args = {
+  disabled: false,
+  onClick: () => undefined
+};
+
+export const SellerSell = Template.bind({});
+SellerSell.args = { ...args };
+
+export const Disabled = Template.bind({});
+Disabled.args = { ...args, disabled: true };

--- a/apps/amazin/src/stories/Product/VideoCard.stories.js
+++ b/apps/amazin/src/stories/Product/VideoCard.stories.js
@@ -1,0 +1,64 @@
+import { SellerButton } from '../../components/Product/VideoScreen/components/ButtonSell';
+import ButtonBuy from '../../components/Product/VideoScreen/components/ButtonBuy';
+import Rating from '../../components/Rating';
+import { getImgUrl } from '../../utils';
+import { VIDEO } from '../../constants';
+
+const NO_IMAGE = process.env.STORYBOOK_BASE + '/images/no-image.png';
+const Template = (props) => (
+  <div className="ml-1 mt-1 p-1">
+    <VideoCard {...props} />
+  </div>
+);
+
+function VideoCard({ movie, portrait }) {
+  return (
+    <div className={`m-card ${portrait ? 'm-card--portrait' : ''}`}>
+      <img
+        src={getImgUrl(
+          movie._id,
+          movie.image ? movie.image.split('^')[1 - portrait] : NO_IMAGE
+        )}
+        alt={movie.name}
+      />
+      <div className="m-card__background">
+        <div className="m-card__text">
+          {(movie?.description?.slice(0, 150) || 'Description ') + '..'}
+
+          <div className="m-card__rating">
+            <Rating rating={8.5} steps={10} numReviews={200} />
+          </div>
+        </div>
+
+        <div className="m-card__more">
+          <SellerButton />
+
+          <ButtonBuy LinkTo={(props) => <div {...props} />} />
+        </div>
+      </div>
+
+      <div className="m-card__info">
+        <div className="m-card__name">{movie.name}</div>
+      </div>
+    </div>
+  );
+}
+
+export default {
+  title: 'Components/Screens/Product/Video Screen/Video Card',
+  component: VideoCard
+};
+
+const args = {
+  movie: VIDEO.EXAMPLES[0],
+  portrait: false
+};
+
+export const Landscape = Template.bind({});
+Landscape.args = { ...args };
+
+export const Portrait = Template.bind({});
+Portrait.args = { ...args, portrait: true };
+
+export const Placeholder = Template.bind({});
+Placeholder.args = { ...args, movie: {} };

--- a/apps/amazin/src/stories/SortFilter.stories.js
+++ b/apps/amazin/src/stories/SortFilter.stories.js
@@ -1,0 +1,22 @@
+import SortFilter from '../components/SortFilter';
+import { SORT } from '../constants';
+
+export default {
+  title: 'Components/Sort Filter',
+  component: SortFilter
+};
+
+const Template = (props) => (
+  <div className="p-1">
+    <SortFilter {...props} />
+  </div>
+);
+
+const SortOpt = Object.values(SORT);
+const args = { order: SortOpt[0].OPT, getUrl: () => undefined };
+
+export const FirstOption = Template.bind({});
+FirstOption.args = { ...args };
+
+export const LastOption = Template.bind({});
+LastOption.args = { ...args, order: SortOpt[SortOpt.length - 1].OPT };

--- a/apps/amazin/src/stories/User/CustomerCard.stories.js
+++ b/apps/amazin/src/stories/User/CustomerCard.stories.js
@@ -1,0 +1,59 @@
+import { customerMenuTemplate } from '../../components/User/CustomerScreen/customerMenuTemplate';
+import CustomerCard, {
+  mapCustomerCardProp
+} from '../../components/User/CustomerScreen/CustomerCard';
+
+export default {
+  title: 'Components/Screens/User/Customer Card',
+  component: CustomerCard
+};
+
+const Template = (props) => (
+  <div className="c-screen customer p-1">
+    <div className="container">
+      <div className="c-boxes mt-1">
+        <CustomerCard {...props} />
+      </div>
+    </div>
+  </div>
+);
+
+const customerCards = customerMenuTemplate.map((p) => ({
+  ...mapCustomerCardProp(p),
+  baseUrl: process.env.STORYBOOK_BASE
+}));
+
+export const Card0 = Template.bind({});
+Card0.args = { ...customerCards[0] };
+export const Card1 = Template.bind({});
+Card1.args = { ...customerCards[1] };
+export const Card2 = Template.bind({});
+Card2.args = { ...customerCards[2] };
+export const Card3 = Template.bind({});
+Card3.args = { ...customerCards[3] };
+export const Card4 = Template.bind({});
+Card4.args = { ...customerCards[4] };
+export const Card5 = Template.bind({});
+Card5.args = { ...customerCards[5] };
+export const Card6 = Template.bind({});
+Card6.args = { ...customerCards[6] };
+export const Card7 = Template.bind({});
+Card7.args = { ...customerCards[7] };
+export const Card8 = Template.bind({});
+Card8.args = { ...customerCards[8] };
+export const Card9 = Template.bind({});
+Card9.args = { ...customerCards[9] };
+
+const TemplateAll = ({ cards }) => (
+  <div className="c-screen customer p-1">
+    <div className="container">
+      <div className="c-boxes">
+        {cards.map((props) => (
+          <CustomerCard {...props} />
+        ))}
+      </div>
+    </div>
+  </div>
+);
+export const AllCards = TemplateAll.bind({});
+AllCards.args = { cards: customerCards };

--- a/apps/amazin/src/stories/button.stories.js
+++ b/apps/amazin/src/stories/button.stories.js
@@ -1,0 +1,47 @@
+import Button from '../components/Button';
+
+export default {
+  title: 'Components/Button',
+  component: Button
+};
+
+const Template = (props) => (
+  <div className="p-1">
+    <Button {...props} />
+  </div>
+);
+
+const args = {
+  label: 'Secondary',
+  wrapClass: '',
+  ariaLabel: '',
+  primary: false,
+  xs: false,
+  className: '',
+  onFocus: () => undefined,
+  onClick: () => undefined,
+  to: undefined
+};
+
+export const Primary = Template.bind({});
+Primary.args = { ...args, primary: true, label: 'Primary' };
+
+export const Secondary = Template.bind({});
+Secondary.args = { ...args };
+
+export const Success = Template.bind({});
+Success.args = { ...args, label: 'Success', className: 'success' };
+
+export const Danger = Template.bind({});
+Danger.args = { ...args, label: 'Danger', className: 'danger' };
+
+export const Disabled = Template.bind({});
+Disabled.args = { ...args, label: 'Disabled', className: 'disabled' };
+
+export const Small = Template.bind({});
+Small.args = {
+  ...args,
+  xs: true,
+  label: 'Small',
+  className: 'small'
+};

--- a/apps/amazin/src/stories/pagination.stories.js
+++ b/apps/amazin/src/stories/pagination.stories.js
@@ -1,0 +1,35 @@
+import Pagination from '../components/Pagination';
+
+export default {
+  title: 'Components/Pagination',
+  component: Pagination
+};
+
+const Template = (props) => <Pagination {...props} />;
+
+const args = {
+  page: 1,
+  pages: 9,
+  help: false,
+  className: '',
+  getUrl: () => undefined,
+  LinkTo: (props) => <div {...props} />
+};
+
+export const Empty = Template.bind({});
+Empty.args = { ...args, page: 0, pages: 1 };
+
+export const Active = Template.bind({});
+Active.args = { ...args, pages: 1 };
+
+export const Disabled = Template.bind({});
+Disabled.args = { ...args, page: 2, pages: 3, className: 'disabled' };
+
+export const FirstPage = Template.bind({});
+FirstPage.args = { ...args, page: 1 };
+
+export const LastPage = Template.bind({});
+LastPage.args = { ...args, page: args.pages };
+
+export const WithHelp = Template.bind({});
+WithHelp.args = { ...args, page: 5, help: true };

--- a/apps/amazin/src/stories/rating.stories.js
+++ b/apps/amazin/src/stories/rating.stories.js
@@ -1,0 +1,33 @@
+import Rating from '../components/Rating';
+
+export default {
+  title: 'Components/Rating',
+  component: Rating
+};
+
+const Template = (props) => <Rating {...props} />;
+
+const args = {
+  rating: 0,
+  numReviews: 200,
+  caption: '',
+  steps: 5
+};
+
+export const Average = Template.bind({});
+Average.args = { ...args, rating: 2.5 };
+
+export const Good = Template.bind({});
+Good.args = { ...args, rating: 4.5 };
+
+export const Bad = Template.bind({});
+Bad.args = { ...args, rating: 0.5 };
+
+export const NoReview = Template.bind({});
+NoReview.args = { ...args, numReviews: 0 };
+
+export const Rating10Steps = Template.bind({});
+Rating10Steps.args = { ...args, rating: 9.5, steps: 10 };
+
+export const WithCaption = Template.bind({});
+WithCaption.args = { ...args, caption: ' Stars & Up' };


### PR DESCRIPTION
## Summary
- Restore the Storybook stories/docs that had been dropped from `nx` from `story72Staging`
- Adapt every story to the current codebase: fixed import paths for components that moved
- Fixed Storybook's own webpack config, which was broken on `nx` before
- Reframed the Intro doc as the design system's front page
- Update files folders structure
- nx run amazin:build-storybook — succeeds, all 12 component stories + 4 doc pages present in the bundle
- nx run amazin:storybook — manually verified running in the browser
